### PR TITLE
Add Excess MAD

### DIFF
--- a/benfordslaw/__init__.py
+++ b/benfordslaw/__init__.py
@@ -1,8 +1,10 @@
 from benfordslaw.benfordslaw import benfordslaw
+from benfordslaw.benfordslaw import compute_excess_mad
+from benfordslaw.benfordslaw import EXCESS_MAD_CONSTANTS
 
 __author__ = 'Erdogan Tasksen'
 __email__ = 'erdogant@gmail.com'
-__version__ = '2.0.1'
+__version__ = '2.0.2'
 
 # module level doc-string
 __doc__ = """
@@ -13,13 +15,18 @@ Test if an empirical (observed) distribution differs significantly from a theore
 The law states that in many naturally occurring collections of numbers, the leading significant digit is likely to be small.
 This method can be used if you want to test whether your set of numbers may be artificial (or manipulated).
 
+New in version 2.0.2:
+- Added Excess MAD (Mean Absolute Deviation) statistic for more reliable fraud detection
+- Added first-two-digits test (pos='first_two') for higher resolution analysis
+- Added 'mad' method option for MAD-based conformity assessment
+
 Example
 -------
 >>> # Import library
 >>> from benfordslaw import benfordslaw
 >>> #
->>> # Initialize
->>> bl = benfordslaw()
+>>> # Initialize with MAD method (recommended for fraud detection)
+>>> bl = benfordslaw(pos='first_two', method='mad')
 >>> #
 >>> df = bl.import_example()
 >>> # Get data for one candidate
@@ -28,11 +35,23 @@ Example
 >>> # Fit
 >>> results = bl.fit(X)
 >>> #
+>>> # Access Excess MAD results
+>>> print(f"Excess MAD: {results['excess_mad']}")
+>>> print(f"Conformity: {results['conformity']}")
+>>> #
 >>> # Figure
 >>> fig, ax = bl.plot()
 
+Quick Excess MAD Computation
+----------------------------
+>>> from benfordslaw import compute_excess_mad
+>>> result = compute_excess_mad(data, pos='first_two')
+>>> print(f"Excess MAD: {result['excess_mad']}")
+
 References
 ----------
-https://github.com/erdogant/benfordslaw
+* Barney, B. J., & Schulzke, K. S. (2016). Moderating "Cry Wolf" Events with Excess MAD
+  in Benford's Law Research and Practice. Journal of Forensic Accounting Research, 1(1), A66-A90.
+* https://github.com/erdogant/benfordslaw
 See README.md file for more information.
 """

--- a/benfordslaw/benfordslaw.py
+++ b/benfordslaw/benfordslaw.py
@@ -16,6 +16,21 @@ from scipy.stats import combine_pvalues
 import matplotlib.pyplot as plt
 import math
 
+
+# %% Constants for Excess MAD calculation
+# These constants are derived from the variance of the binomial distribution for each digit test.
+# For the first-two-digits test, C = 158.8 as derived in Barney & Schulzke (2016).
+# For other tests, constants are computed using the formula:
+# C = K^2 * π / (2 * (Σ sqrt(p_k * (1 - p_k)))^2)
+# where K is the number of digit categories and p_k are the Benford probabilities.
+EXCESS_MAD_CONSTANTS = {
+    'first_two': 158.8,  # First-two-digits test (90 categories, k=10..99)
+    1: 21.27,            # First digit test (9 categories, k=1..9)
+    2: 30.30,            # Second digit test (10 categories, k=0..9)
+    3: 31.83,            # Third digit test (10 categories, approximately uniform)
+}
+
+
 # %% Class
 class benfordslaw:
     """Class benfordslaw."""
@@ -30,38 +45,56 @@ class benfordslaw:
         alpha : float [0-1], (default: 0.05).
             Only used to print message about statistical significant.
         method : string, (Default: 'chi2').
-            * 'chi2'
-            * 'ks'
-            * None (combined pvalues based fishers-method)
-        pos : int [-9,..,9], (default: 1).
-            Digit position the be analyzed. 1: first digit, 2: second digit etc. -1: the last position, -2: second last digit etc
+            * 'chi2' : Chi-square test
+            * 'ks' : Kolmogorov-Smirnov test
+            * 'mad' : Mean Absolute Deviation with Excess MAD adjustment (recommended for fraud detection)
+            * None : Combined p-values based on Fisher's method
+        pos : int or str [-9,..,9] or 'first_two', (default: 1).
+            Digit position to be analyzed.
+            * 1: first digit
+            * 2: second digit
+            * 3: third digit (etc.)
+            * -1: last digit
+            * -2: second last digit (etc.)
+            * 'first_two': First two digits combined (recommended for Benford's Law analysis,
+              provides higher resolution with 90 categories instead of 9)
         verbose : int, optional
             Print message to screen. The default is 3.
 
+        References
+        ----------
+        * Barney, B. J., & Schulzke, K. S. (2016). Moderating "Cry Wolf" Events with Excess MAD
+          in Benford's Law Research and Practice. Journal of Forensic Accounting Research, 1(1), A66-A90.
+
         """
-        if (alpha is None): alpha=1
+        if (alpha is None): alpha = 1
         self.alpha = alpha
         self.method = method
         self.pos = pos
         self.verbose = verbose
 
-        # Benford's Law percentage-distribution for leading digits 1-9
-        if pos==1:
+        # Benford's Law percentage-distribution for leading digits
+        if pos == 'first_two':
+            # First-two-digits test: 90 categories (10-99)
+            # Probabilities from Benford's Law: log10(1 + 1/k) for k=10..99
+            self.leading_digits = np.array([math.log(1 + (1 / k), 10) for k in range(10, 100)]) * 100
+            self.digit_range = range(10, 100)
+        elif pos == 1:
             self.leading_digits = np.array(list(map(lambda x: math.log(1 + (1 / x), 10), np.arange(1, 10)))) * 100
             self.digit_range = range(1, 10)
-        elif pos==2:
+        elif pos == 2:
             self.leading_digits = [12, 11.4, 10.9, 10.4, 10, 9.7, 9.3, 9, 8.8, 8.5]
             self.digit_range = range(0, 10)
-        elif pos==3:
+        elif pos == 3:
             self.leading_digits = [10.2, 10.1, 10.1, 10.1, 10.0, 10.0, 9.9, 9.9, 9.9, 9.8]
             self.digit_range = range(0, 10)
-        elif pos>3 or pos<0:
-            if verbose>=3: print(f'[benfordslaw] >The is no leading digit distribution explicitly specified for digit [{pos}] and therefore the Uniform distribution is used instead.')
+        elif pos == 0:
+            raise Exception('[benfordslaw] >There is no leading digit distribution for the 0 digit!')
+        elif isinstance(pos, int) and (pos > 3 or pos < 0):
+            if verbose >= 3: print(f'[benfordslaw] >The is no leading digit distribution explicitly specified for digit [{pos}] and therefore the Uniform distribution is used instead.')
             # Approximation, near-uniform distribution
             self.leading_digits = [10.0] * 10
             self.digit_range = range(0, 10)
-        else:
-            raise Exception('[benfordslaw] >There is no leading digit distribution for the 0 digit!')
 
     def fit(self, X):
         """Test if an empirical (observed) distribution significantly differs from a theoretical (expected, Benfords) distribution.
@@ -75,7 +108,7 @@ class benfordslaw:
         Assumptions of the data:
            1. The numbers need to be random and not assigned, with no imposed minimums or maximums.
            2. The numbers should cover several orders of magnitude
-           3. Dataset should preferably cover at least 1000 samples. Though Benford’s law has been shown to hold true for datasets containing as few as 50 numbers.
+           3. Dataset should preferably cover at least 1000 samples. Though Benford's law has been shown to hold true for datasets containing as few as 50 numbers.
 
         Parameters
         ----------
@@ -87,8 +120,8 @@ class benfordslaw:
         >>> # Import library
         >>> from benfordslaw import benfordslaw
         >>> #
-        >>> # Initialize
-        >>> bl = benfordslaw(pos=1)
+        >>> # Initialize with MAD method (recommended for fraud detection)
+        >>> bl = benfordslaw(pos='first_two', method='mad')
         >>> #
         >>> # Get data for one candidate
         >>> df = bl.import_example()
@@ -97,33 +130,74 @@ class benfordslaw:
         >>> # Fit
         >>> results = bl.fit(X)
         >>> #
+        >>> # Access Excess MAD (negative values indicate conformity to Benford's Law)
+        >>> print(f"Excess MAD: {results['excess_mad']}")
+        >>> #
         >>> # Figure
         >>> fig, ax = bl.plot()
 
         Returns
         -------
-        dict.
+        dict containing:
+            P : float
+                P-value from the statistical test (NaN for MAD method).
+            t : float
+                Test statistic (Excess MAD for MAD method).
+            P_significant : bool
+                Whether the result is significant at alpha level.
+            percentage_emp : ndarray
+                Empirical digit frequencies.
+            mad : float
+                Mean Absolute Deviation from Benford's Law.
+            expected_mad : float
+                Expected MAD for a pure Benford set of the same size.
+            excess_mad : float
+                Excess MAD = MAD - E(MAD). Negative values indicate conformity,
+                positive values indicate deviation from Benford's Law.
+            conformity : str
+                Conformity assessment based on MAD thresholds ('close conformity',
+                'acceptable conformity', 'marginally acceptable conformity', or 'nonconforming').
+            N : int
+                Number of observations used in the analysis.
+
+        References
+        ----------
+        * Barney, B. J., & Schulzke, K. S. (2016). Moderating "Cry Wolf" Events with Excess MAD
+          in Benford's Law Research and Practice. Journal of Forensic Accounting Research, 1(1), A66-A90.
+        * Nigrini, M. (2012). Benford's Law: Applications for Forensic Accounting, Auditing, and
+          Fraud Detection. Hoboken, NJ: John Wiley & Sons.
 
         """
         # Make distribution first digits
-        if self.verbose>=3: print("[benfordslaw] >Analyzing digit position: [%s]" %(self.pos))
+        if self.verbose >= 3: print("[benfordslaw] >Analyzing digit position: [%s]" % (self.pos))
         # Convert pandas dataframe to numpy array
         if isinstance(X, pd.DataFrame): X = X.values.ravel()
-        # Count digit
-        counts_emp, percentage_emp, total_count, digit = _count_digit(X, self.pos, self.digit_range)
+        # Count digit based on position type
+        if self.pos == 'first_two':
+            counts_emp, percentage_emp, total_count, digit = _count_first_two_digits(X)
+        else:
+            counts_emp, percentage_emp, total_count, digit = _count_digit(X, self.pos, self.digit_range)
         # Expected counts
         counts_exp = self._get_expected_counts(total_count)
 
-        # Compute Pvalues
+        # Compute MAD and Excess MAD (always computed regardless of method)
+        mad, expected_mad, excess_mad, conformity = self._compute_mad_statistics(counts_emp, total_count)
+
+        # Compute Pvalues based on method
         tstats, Praw = np.nan, np.nan
         if total_count > 0:
-            if self.method=='chi2':
+            if self.method == 'chi2':
                 try:
                     tstats, Praw = chisquare(counts_emp, f_exp=counts_exp)
                 except:
                     raise Exception('The relative tolerance of the chisquare test is not reached. Try using another method such as "method=ks". This is not a bug but a feature: "https://github.com/scipy/scipy/issues/13362" ')
-            elif self.method=='ks':
+            elif self.method == 'ks':
                 tstats, Praw = ks_2samp(counts_emp, counts_exp)
+            elif self.method == 'mad':
+                # For MAD method, use excess_mad as the test statistic
+                # P-value is not applicable for MAD-based assessment
+                tstats = excess_mad
+                Praw = np.nan
             else:
                 stats1, Praw1 = chisquare(counts_emp, f_exp=counts_exp)
                 tstats2, Praw2 = ks_2samp(counts_emp, counts_exp)
@@ -131,26 +205,152 @@ class benfordslaw:
                 self.method = 'P_ensemble'
 
         # Show message
-        if np.isnan(Praw) and (self.verbose>=3):
+        if self.method == 'mad':
+            if self.verbose >= 3:
+                if excess_mad <= 0:
+                    print("[benfordslaw] >[mad] No anomaly detected. Excess MAD=%g (%s)" % (excess_mad, conformity))
+                else:
+                    print("[benfordslaw] >[mad] Potential anomaly. Excess MAD=%g (%s)" % (excess_mad, conformity))
+        elif np.isnan(Praw) and (self.verbose >= 3):
             print(f"[benfordslaw] >No data available for this position.")
-        elif (Praw<=self.alpha) and (self.verbose>=3):
-            print("[benfordslaw] >[%s] Anomaly detected! P=%g, Tstat=%g" %(self.method, Praw, tstats))
-        elif (Praw>self.alpha) and self.verbose>=3:
-            print("[benfordslaw] >[%s] No anomaly detected. P=%g, Tstat=%g" %(self.method, Praw, tstats))
+        elif (Praw <= self.alpha) and (self.verbose >= 3):
+            print("[benfordslaw] >[%s] Anomaly detected! P=%g, Tstat=%g" % (self.method, Praw, tstats))
+        elif (Praw > self.alpha) and self.verbose >= 3:
+            print("[benfordslaw] >[%s] No anomaly detected. P=%g, Tstat=%g" % (self.method, Praw, tstats))
 
         # Store
         self.results = {}
         self.results['P'] = Praw
         self.results['t'] = tstats
-        self.results['P_significant'] = Praw<=self.alpha
+        self.results['P_significant'] = Praw <= self.alpha if not np.isnan(Praw) else (excess_mad > 0)
         self.results['percentage_emp'] = np.c_[digit, percentage_emp]
+        # Always include MAD statistics
+        self.results['mad'] = mad
+        self.results['expected_mad'] = expected_mad
+        self.results['excess_mad'] = excess_mad
+        self.results['conformity'] = conformity
+        self.results['N'] = int(total_count)
 
         # return
         return self.results
 
+    def _compute_mad_statistics(self, counts_emp, total_count):
+        """Compute MAD, Expected MAD, and Excess MAD statistics.
+
+        Mean Absolute Deviation (MAD) measures the average absolute difference between
+        observed and expected digit frequencies. Excess MAD adjusts for sample size,
+        providing a more reliable measure for detecting anomalies in Benford's Law analysis.
+
+        Parameters
+        ----------
+        counts_emp : array-like
+            Empirical counts for each digit category.
+        total_count : int
+            Total number of observations.
+
+        Returns
+        -------
+        mad : float
+            Mean Absolute Deviation.
+        expected_mad : float
+            Expected MAD for a pure Benford set of the same size (E(MAD) ≈ 1/√(C×N)).
+        excess_mad : float
+            Excess MAD = MAD - E(MAD). Values below 0 indicate conformity.
+        conformity : str
+            Conformity assessment based on Nigrini (2012) thresholds.
+
+        References
+        ----------
+        * Nigrini, M. (2012). Benford's Law: Applications for Forensic Accounting,
+          Auditing, and Fraud Detection. Hoboken, NJ: John Wiley & Sons.
+        * Barney, B. J., & Schulzke, K. S. (2016). Moderating "Cry Wolf" Events with
+          Excess MAD in Benford's Law Research and Practice.
+
+        """
+        if total_count == 0:
+            return np.nan, np.nan, np.nan, 'insufficient data'
+
+        # Calculate observed proportions
+        observed_proportions = np.array(counts_emp) / total_count
+
+        # Calculate expected proportions (from leading_digits, which are in percentages)
+        expected_proportions = np.array(self.leading_digits) / 100
+
+        # Calculate MAD: mean of absolute deviations
+        # MAD = (1/K) × Σ|Obs_k/N - Exp_k|
+        K = len(self.leading_digits)
+        mad = np.sum(np.abs(observed_proportions - expected_proportions)) / K
+
+        # Calculate Expected MAD for a pure Benford set
+        # E(MAD) ≈ 1 / √(C × N) where C depends on the digit test
+        C = self._get_excess_mad_constant()
+        expected_mad = 1.0 / math.sqrt(C * total_count)
+
+        # Calculate Excess MAD (the key contribution from Barney & Schulzke 2016)
+        excess_mad = mad - expected_mad
+
+        # Determine conformity based on Nigrini (2012) thresholds
+        # Thresholds are calibrated for the first-two-digits test
+        if self.pos == 'first_two':
+            # Original thresholds from Nigrini (2012) for first-two-digits test
+            if mad < 0.0012:
+                conformity = 'close conformity'
+            elif mad < 0.0018:
+                conformity = 'acceptable conformity'
+            elif mad < 0.0022:
+                conformity = 'marginally acceptable conformity'
+            else:
+                conformity = 'nonconforming'
+        else:
+            # For other digit tests, use Excess MAD-based interpretation
+            # Negative Excess MAD indicates better-than-expected conformity
+            if excess_mad < 0:
+                conformity = 'close conformity'
+            elif excess_mad < 0.001:
+                conformity = 'acceptable conformity'
+            elif excess_mad < 0.002:
+                conformity = 'marginally acceptable conformity'
+            else:
+                conformity = 'nonconforming'
+
+        return mad, expected_mad, excess_mad, conformity
+
+    def _get_excess_mad_constant(self):
+        """Get the constant C for Expected MAD calculation.
+
+        The constant C is derived from the variance of the binomial distribution
+        for each digit test type. For the first-two-digits test, C = 158.8 as
+        derived in Barney & Schulzke (2016).
+
+        The formula for C is:
+        C = K² × π / (2 × (Σ √(p_k × (1 - p_k)))²)
+
+        where K is the number of digit categories and p_k are the Benford probabilities.
+
+        Returns
+        -------
+        float
+            The constant C for the current digit test.
+
+        References
+        ----------
+        * Barney, B. J., & Schulzke, K. S. (2016). Moderating "Cry Wolf" Events with
+          Excess MAD in Benford's Law Research and Practice.
+
+        """
+        if self.pos == 'first_two':
+            return EXCESS_MAD_CONSTANTS['first_two']
+        elif self.pos in EXCESS_MAD_CONSTANTS:
+            return EXCESS_MAD_CONSTANTS[self.pos]
+        else:
+            # For other positions, use an approximation based on the distribution
+            # C ≈ K² × π / 2 for approximately uniform distributions
+            K = len(self.leading_digits)
+            return K * K * math.pi / 2
+
     # Plot
     def plot(self, title='', fontsize=16, barcolor='black', barwidth=0.3, label='Empirical distribution', figsize=(15, 8), grid=True):
-        """Make bar chart of observed vs expected 1st digit frequency in percent.
+        """Make bar chart of observed vs expected digit frequency in percent.
 
         Parameters
         ----------
@@ -179,38 +379,51 @@ class benfordslaw:
         rects1 = ax.bar(x, data_percentage[:, 1], width=barwidth, color=barcolor, alpha=0.8, label=label)
 
         plt.plot(x, data_percentage[:, 1], color='black', linewidth=0.8)
-        # ax.scatter(x, data_percentage, s=150, c='red', zorder=2)
         # attach a text label above each bar displaying its height
         for rect, perc in zip(rects1, data_percentage[:, 1]):
             if not np.isnan(perc):
                 height = rect.get_height()
-                ax.text(rect.get_x() + rect.get_width() / 2, height, '{:0.1f}%'.format(height), ha='center', va='bottom', fontsize=13)
+                # Only show labels for first digit or first_two with limited labels
+                if self.pos != 'first_two':
+                    ax.text(rect.get_x() + rect.get_width() / 2, height, '{:0.1f}%'.format(height), ha='center', va='bottom', fontsize=13)
 
         # Plot expected benfords values
-        ax.scatter(x, self.leading_digits, s=150, c='red', zorder=2, label='Benfords distribution')
-        # ax.bar(x + width, BENFORDLD, width=width, color='blue', alpha=0.8, label='Benfords distribution')
-        # plt.plot(x + width, BENFORDLD, color='blue', linewidth=0.8)
+        ax.scatter(x, self.leading_digits, s=150 if self.pos != 'first_two' else 30, c='red', zorder=2, label='Benfords distribution')
 
-        if self.results['P']<=self.alpha:
-            title = title + "\nAnomaly detected! P=%g, Tstat=%g" %(self.results['P'], self.results['t'])
-        else:
-            title = title + "\nNo anomaly detected. P=%g, Tstat=%g" %(self.results['P'], self.results['t'])
+        # Build title based on method
+        if self.method == 'mad':
+            title = title + "\nExcess MAD=%g (%s)" % (self.results['excess_mad'], self.results['conformity'])
+        elif not np.isnan(self.results['P']) and self.results['P'] <= self.alpha:
+            title = title + "\nAnomaly detected! P=%g, Tstat=%g" % (self.results['P'], self.results['t'])
+        elif not np.isnan(self.results['P']):
+            title = title + "\nNo anomaly detected. P=%g, Tstat=%g" % (self.results['P'], self.results['t'])
+
+        # Add MAD info to title if available
+        if 'mad' in self.results and self.method != 'mad':
+            title = title + "\nMAD=%g, Excess MAD=%g" % (self.results['mad'], self.results['excess_mad'])
 
         # Add some text for labels, title and custom x-axis tick labels, etc.
         ax.set_title(title, fontsize=fontsize)
         ax.set_ylabel('Frequency (%)', fontsize=fontsize)
         ax.set_xlabel('Digits', fontsize=fontsize)
-        ax.set_xticks(x.astype(int))
-        ax.set_xticklabels(x.astype(int), fontsize=fontsize)
+
+        # Adjust x-axis for first_two digits test
+        if self.pos == 'first_two':
+            # Show fewer tick labels for readability
+            tick_positions = list(range(10, 100, 10))
+            ax.set_xticks(tick_positions)
+            ax.set_xticklabels(tick_positions, fontsize=fontsize - 2)
+        else:
+            ax.set_xticks(x.astype(int))
+            ax.set_xticklabels(x.astype(int), fontsize=fontsize)
 
         if grid:
-            ax.grid(True, which='both', linestyle='--', linewidth=0.9, alpha=0.8)  # Customize as needed
+            ax.grid(True, which='both', linestyle='--', linewidth=0.9, alpha=0.8)
 
         # Hide the right and top spines & add legend
         ax.spines['right'].set_visible(False)
         ax.spines['top'].set_visible(False)
         ax.legend(prop={'size': 15}, frameon=False)
-        # Set legend
         ax.legend()
 
         plt.show()
@@ -257,7 +470,7 @@ class benfordslaw:
 # %% Counts and the frequencies in percentage for the first digit
 def _count_first_digit(data):
     # Get only non-zero values
-    data = data[data>=1]
+    data = data[data >= 1]
 
     # Get the first digits
     first_digits = list(map(lambda x: int(str(x)[0]), data))
@@ -275,6 +488,59 @@ def _count_first_digit(data):
     empirical_percentage = [(i / total_count) * 100 for i in empirical_counts]
     # Return
     return(empirical_counts, empirical_percentage, total_count, digit)
+
+
+# %% Counts and the frequencies in percentage for the first two digits
+def _count_first_two_digits(data):
+    """Count the first two digits of each number in the data.
+
+    Parameters
+    ----------
+    data : array-like
+        Input data containing numbers.
+
+    Returns
+    -------
+    empirical_counts : ndarray
+        Counts for each first-two-digit pair (10-99).
+    empirical_percentage : list
+        Percentage for each first-two-digit pair.
+    total_count : int
+        Total number of valid observations.
+    digit : list
+        List of digit pairs (10-99).
+
+    """
+    # Convert to numpy array if needed
+    data = np.asarray(data).flatten()
+
+    # Get only values with at least 2 digits (>= 10)
+    data = data[data >= 10]
+
+    # Get the first two digits
+    first_two_digits = []
+    for x in data:
+        s = str(int(abs(x)))
+        if len(s) >= 2:
+            first_two_digits.append(int(s[:2]))
+
+    # Count occurences for each pair from 10 to 99
+    empirical_counts = np.zeros(90)
+    digit = []
+    for i in range(10, 100):
+        empirical_counts[i - 10] = first_two_digits.count(i)
+        digit.append(i)
+
+    # Total amount
+    total_count = sum(empirical_counts)
+    empirical_percentage = [np.nan] * len(empirical_counts)
+
+    # Make percentage
+    if total_count > 0:
+        empirical_percentage = [(i / total_count) * 100 for i in empirical_counts]
+
+    # Return
+    return empirical_counts, empirical_percentage, total_count, digit
 
 
 # %% Counts and the frequencies in percentage for the second digit
@@ -309,10 +575,62 @@ def _count_digit(data, d, digit_range):
     total_count = sum(empirical_counts)
     empirical_percentage = [np.nan] * len(empirical_counts)
     # Make percentage
-    if total_count>0:
+    if total_count > 0:
         empirical_percentage = [(i / total_count) * 100 for i in empirical_counts]
     # Return
     return empirical_counts, empirical_percentage, total_count, digitnr
+
+
+# %% Standalone function for computing Excess MAD
+def compute_excess_mad(data, pos='first_two'):
+    """Compute Excess MAD for a dataset without creating a benfordslaw object.
+
+    This is a convenience function that computes the Excess MAD statistic
+    directly, which is useful for quick assessments of Benford's Law conformity.
+
+    Parameters
+    ----------
+    data : array-like
+        Input data containing numbers.
+    pos : str or int, (default: 'first_two')
+        Digit position to analyze. See benfordslaw class for options.
+
+    Returns
+    -------
+    dict containing:
+        mad : float
+            Mean Absolute Deviation.
+        expected_mad : float
+            Expected MAD for a pure Benford set.
+        excess_mad : float
+            Excess MAD (MAD - E(MAD)).
+        conformity : str
+            Conformity assessment.
+        N : int
+            Number of observations.
+
+    Examples
+    --------
+    >>> from benfordslaw import compute_excess_mad
+    >>> data = [123, 456, 789, 1011, 1213]
+    >>> result = compute_excess_mad(data, pos='first_two')
+    >>> print(f"Excess MAD: {result['excess_mad']}")
+
+    References
+    ----------
+    * Barney, B. J., & Schulzke, K. S. (2016). Moderating "Cry Wolf" Events with Excess MAD
+      in Benford's Law Research and Practice. Journal of Forensic Accounting Research, 1(1), A66-A90.
+
+    """
+    bl = benfordslaw(pos=pos, method='mad', verbose=0)
+    results = bl.fit(np.asarray(data))
+    return {
+        'mad': results['mad'],
+        'expected_mad': results['expected_mad'],
+        'excess_mad': results['excess_mad'],
+        'conformity': results['conformity'],
+        'N': results['N']
+    }
 
 
 # %% Main

--- a/benfordslaw/examples.py
+++ b/benfordslaw/examples.py
@@ -172,4 +172,25 @@ for candidate in df['candidate'].unique():
     bl.fit(X)
     bl.plot(title=candidate)
 
+# %% Excess MAD - sample size adjusted conformity measure
+# Reference: Barney & Schulzke (2016), Journal of Forensic Accounting Research
+from benfordslaw import benfordslaw, compute_excess_mad
+
+# First-two-digits test with MAD method (recommended for fraud detection)
+bl = benfordslaw(pos='first_two', method='mad')
+df = bl.import_example(data='elections_usa')
+X = df['votes'].loc[df['candidate'] == 'Donald Trump'].values
+
+results = bl.fit(X)
+print(f"MAD: {results['mad']:.6f}")
+print(f"Expected MAD: {results['expected_mad']:.6f}")
+print(f"Excess MAD: {results['excess_mad']:.6f}")  # Negative = good conformity
+print(f"Conformity: {results['conformity']}")
+
+bl.plot(title='Excess MAD Analysis - Donald Trump')
+
+# Quick computation using convenience function
+quick_result = compute_excess_mad(X, pos='first_two')
+print(f"Quick Excess MAD: {quick_result['excess_mad']:.6f}")
+
 # %%

--- a/benfordslaw/tests/test_benfordslaw.py
+++ b/benfordslaw/tests/test_benfordslaw.py
@@ -3,7 +3,10 @@
 
 import numpy as np
 from benfordslaw import benfordslaw
+from benfordslaw import compute_excess_mad
+from benfordslaw import EXCESS_MAD_CONSTANTS
 import unittest
+
 
 class TestBENFORDSLAW(unittest.TestCase):
     def test_benfordslaw_digits(self):
@@ -35,7 +38,7 @@ class TestBENFORDSLAW(unittest.TestCase):
         for method in methods:
             bl = benfordslaw(method=method)
             out = bl.fit(X)
-            assert np.all(np.isin([*out.keys()], ['P', 't', 'percentage_emp', 'P_significant']))
+            assert np.all(np.isin([*out.keys()], ['P', 't', 'percentage_emp', 'P_significant', 'mad', 'expected_mad', 'excess_mad', 'conformity', 'N']))
 
         # TEST 2: check chi2
         bl = benfordslaw(method='chi2')
@@ -59,5 +62,242 @@ class TestBENFORDSLAW(unittest.TestCase):
         Iloc = df['candidate']=='Donald Trump'
         X = df['votes'].loc[Iloc]
         results = bl.fit(X)
-        np.all(np.isin([*results.keys()], ['P', 't', 'percentage_emp', 'P_significant']))
+        np.all(np.isin([*results.keys()], ['P', 't', 'percentage_emp', 'P_significant', 'mad', 'expected_mad', 'excess_mad', 'conformity', 'N']))
         assert np.all(results['percentage_emp'][:,1]==[31.64521544487969, 16.508114157806382, 12.479015109121432, 9.820928931169558, 7.862339115836598, 6.3794068270845, 5.8477895914941245, 4.616675993284835, 4.8405148293228875])
+
+
+class TestExcessMAD(unittest.TestCase):
+    """Test suite for Excess MAD functionality."""
+
+    def test_mad_method_first_digit(self):
+        """Test MAD method with first digit analysis."""
+        bl = benfordslaw(method='mad', pos=1, verbose=0)
+        df = bl.import_example(data='elections_usa', verbose=0)
+        X = df['votes'].loc[df['candidate'] == 'Donald Trump'].values
+        results = bl.fit(X)
+
+        # Check that MAD statistics are computed
+        assert 'mad' in results
+        assert 'expected_mad' in results
+        assert 'excess_mad' in results
+        assert 'conformity' in results
+        assert 'N' in results
+
+        # MAD should be non-negative
+        assert results['mad'] >= 0
+
+        # Expected MAD should be positive for valid N
+        assert results['expected_mad'] > 0
+
+        # N should match the data count (approximately, after filtering)
+        assert results['N'] > 0
+
+    def test_mad_method_first_two_digits(self):
+        """Test MAD method with first-two-digits analysis (paper's recommended approach)."""
+        bl = benfordslaw(method='mad', pos='first_two', verbose=0)
+        df = bl.import_example(data='elections_usa', verbose=0)
+        X = df['votes'].loc[df['candidate'] == 'Donald Trump'].values
+        results = bl.fit(X)
+
+        # Check that all MAD statistics are present
+        assert 'mad' in results
+        assert 'expected_mad' in results
+        assert 'excess_mad' in results
+        assert 'conformity' in results
+
+        # For first-two-digits test, conformity should be one of the defined categories
+        valid_conformities = ['close conformity', 'acceptable conformity',
+                              'marginally acceptable conformity', 'nonconforming', 'insufficient data']
+        assert results['conformity'] in valid_conformities
+
+    def test_excess_mad_formula(self):
+        """Test that Excess MAD = MAD - E(MAD)."""
+        bl = benfordslaw(method='mad', pos='first_two', verbose=0)
+        df = bl.import_example(data='elections_usa', verbose=0)
+        X = df['votes'].loc[df['candidate'] == 'Donald Trump'].values
+        results = bl.fit(X)
+
+        # Verify the formula: excess_mad = mad - expected_mad
+        calculated_excess = results['mad'] - results['expected_mad']
+        assert np.isclose(results['excess_mad'], calculated_excess, rtol=1e-10)
+
+    def test_expected_mad_formula(self):
+        """Test that E(MAD) ≈ 1/√(C×N) for first-two-digits."""
+        import math
+        bl = benfordslaw(method='mad', pos='first_two', verbose=0)
+        df = bl.import_example(data='elections_usa', verbose=0)
+        X = df['votes'].loc[df['candidate'] == 'Donald Trump'].values
+        results = bl.fit(X)
+
+        # Calculate expected MAD using the formula from the paper
+        C = EXCESS_MAD_CONSTANTS['first_two']  # 158.8
+        N = results['N']
+        expected_mad_calculated = 1.0 / math.sqrt(C * N)
+
+        # Verify it matches
+        assert np.isclose(results['expected_mad'], expected_mad_calculated, rtol=1e-10)
+
+    def test_excess_mad_constants(self):
+        """Test that Excess MAD constants are defined correctly."""
+        # Check that constants exist for key digit tests
+        assert 'first_two' in EXCESS_MAD_CONSTANTS
+        assert 1 in EXCESS_MAD_CONSTANTS
+        assert 2 in EXCESS_MAD_CONSTANTS
+
+        # The constant for first-two-digits should be 158.8 (from the paper)
+        assert EXCESS_MAD_CONSTANTS['first_two'] == 158.8
+
+    def test_compute_excess_mad_function(self):
+        """Test the standalone compute_excess_mad function."""
+        data = np.random.lognormal(mean=5, sigma=2, size=1000) * 100
+
+        result = compute_excess_mad(data, pos='first_two')
+
+        # Check output structure
+        assert 'mad' in result
+        assert 'expected_mad' in result
+        assert 'excess_mad' in result
+        assert 'conformity' in result
+        assert 'N' in result
+
+        # Verify the formula
+        assert np.isclose(result['excess_mad'], result['mad'] - result['expected_mad'], rtol=1e-10)
+
+    def test_first_two_digits_90_categories(self):
+        """Test that first-two-digits has 90 categories (10-99)."""
+        bl = benfordslaw(pos='first_two', verbose=0)
+
+        # Check that digit_range covers 10-99
+        assert len(bl.digit_range) == 90
+        assert min(bl.digit_range) == 10
+        assert max(bl.digit_range) == 99
+
+        # Check that leading_digits has 90 values
+        assert len(bl.leading_digits) == 90
+
+    def test_conformity_thresholds_first_two(self):
+        """Test conformity thresholds for first-two-digits test."""
+        bl = benfordslaw(method='mad', pos='first_two', verbose=0)
+
+        # Create a known dataset that should conform well to Benford's Law
+        # Using lognormal distribution which typically follows Benford's Law
+        np.random.seed(42)
+        data = np.random.lognormal(mean=5, sigma=2, size=5000) * 100
+
+        results = bl.fit(data)
+
+        # Lognormal data should generally show good conformity
+        # (though this is a probabilistic test)
+        assert results['conformity'] in ['close conformity', 'acceptable conformity',
+                                          'marginally acceptable conformity', 'nonconforming']
+
+    def test_mad_statistics_always_computed(self):
+        """Test that MAD statistics are always computed regardless of method."""
+        methods = ['chi2', 'ks', 'mad', None]
+        bl_base = benfordslaw(verbose=0)
+        df = bl_base.import_example(data='elections_usa', verbose=0)
+        X = df['votes'].loc[df['candidate'] == 'Donald Trump'].values
+
+        for method in methods:
+            bl = benfordslaw(method=method, verbose=0)
+            results = bl.fit(X)
+
+            # MAD statistics should always be present
+            assert 'mad' in results, f"MAD missing for method {method}"
+            assert 'expected_mad' in results, f"expected_mad missing for method {method}"
+            assert 'excess_mad' in results, f"excess_mad missing for method {method}"
+            assert 'conformity' in results, f"conformity missing for method {method}"
+
+    def test_excess_mad_sample_size_effect(self):
+        """Test that Excess MAD properly accounts for sample size."""
+        import math
+
+        # Generate Benford-like data
+        np.random.seed(42)
+        large_data = np.random.lognormal(mean=5, sigma=2, size=10000) * 100
+        small_data = large_data[:500]
+
+        bl = benfordslaw(method='mad', pos='first_two', verbose=0)
+
+        results_large = bl.fit(large_data)
+        results_small = bl.fit(small_data)
+
+        # Expected MAD should be smaller for larger datasets
+        assert results_large['expected_mad'] < results_small['expected_mad']
+
+        # The difference should follow the formula ratio
+        # E(MAD)_small / E(MAD)_large ≈ √(N_large / N_small)
+        expected_ratio = math.sqrt(results_large['N'] / results_small['N'])
+        actual_ratio = results_small['expected_mad'] / results_large['expected_mad']
+        assert np.isclose(expected_ratio, actual_ratio, rtol=0.01)
+
+    def test_negative_excess_mad_indicates_conformity(self):
+        """Test that negative Excess MAD indicates good conformity."""
+        bl = benfordslaw(method='mad', pos='first_two', verbose=0)
+
+        # Generate data that follows Benford's Law well
+        np.random.seed(123)
+        # Using a large sample of lognormal data
+        data = np.random.lognormal(mean=6, sigma=3, size=10000) * 100
+
+        results = bl.fit(data)
+
+        # If Excess MAD is negative, conformity should indicate good fit
+        # (though this is probabilistic and depends on the data)
+        if results['excess_mad'] < 0:
+            assert results['conformity'] in ['close conformity', 'acceptable conformity']
+
+    def test_different_digit_positions(self):
+        """Test MAD calculation for different digit positions."""
+        positions = [1, 2, 3, 'first_two']
+
+        bl_base = benfordslaw(verbose=0)
+        df = bl_base.import_example(data='elections_usa', verbose=0)
+        X = df['votes'].loc[df['candidate'] == 'Donald Trump'].values
+
+        for pos in positions:
+            bl = benfordslaw(method='mad', pos=pos, verbose=0)
+            results = bl.fit(X)
+
+            # All should have valid MAD statistics
+            assert not np.isnan(results['mad']), f"NaN MAD for pos={pos}"
+            assert not np.isnan(results['expected_mad']), f"NaN expected_mad for pos={pos}"
+            assert not np.isnan(results['excess_mad']), f"NaN excess_mad for pos={pos}"
+
+
+class TestFirstTwoDigits(unittest.TestCase):
+    """Test suite for first-two-digits functionality."""
+
+    def test_first_two_digit_counting(self):
+        """Test that first-two-digits are correctly extracted and counted."""
+        bl = benfordslaw(pos='first_two', verbose=0)
+
+        # Test with known data
+        data = np.array([10, 11, 12, 19, 20, 25, 99, 100, 1000, 10000])
+        results = bl.fit(data)
+
+        # Check that we got 90 categories
+        assert results['percentage_emp'].shape[0] == 90
+
+    def test_first_two_benford_probabilities(self):
+        """Test that first-two-digit Benford probabilities sum to 1."""
+        bl = benfordslaw(pos='first_two', verbose=0)
+
+        # Leading digits are in percentage, should sum to 100
+        total_prob = np.sum(bl.leading_digits)
+        assert np.isclose(total_prob, 100.0, rtol=1e-5)
+
+    def test_first_two_digit_minimum_value(self):
+        """Test that values less than 10 are excluded from first-two-digits test."""
+        bl = benfordslaw(pos='first_two', verbose=0)
+
+        # All values less than 10
+        data = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9])
+        results = bl.fit(data)
+
+        # Should have no valid observations
+        assert results['N'] == 0
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add Excess MAD statistic and first-two-digits test

- Add Excess MAD statistic based on Barney & Schulzke (2016), which adjusts for sample size to reduce false positives in small datasets
- Add first-two-digits test (pos='first_two') with 90 categories
- Add 'mad' method option for MAD-based conformity assessment with thresholds from Nigrini (2012)
- Add compute_excess_mad() convenience function for quick analysis
- Export EXCESS_MAD_CONSTANTS for transparency
- Update version to 2.0.2
- Add test suite for new functionality
- Update documentation with references and examples